### PR TITLE
Add CSS escapes to background-images in twig templates

### DIFF
--- a/templates/item.html.twig
+++ b/templates/item.html.twig
@@ -14,7 +14,7 @@
                 <h1 class="post-full-title">{{ page.title }}</h1>
             </header>
             {% if page.media.images|first %}
-                <figure class="post-full-image" style="background-image: url({{ page.media.images|first.url }})"></figure>
+                <figure class="post-full-image" style="background-image: url({{ page.media.images|first.url|escape('css') }})"></figure>
             {% else %}
                 <figure class="post-full-image"
                         style="background-image: url(https://source.unsplash.com/{{ theme_config.header.featured_image }})" alt="cover">

--- a/templates/partials/header.html.twig
+++ b/templates/partials/header.html.twig
@@ -1,4 +1,4 @@
-<header class="site-header outer " style="background-image:  url('{{ page.media[page.header.primaryImage|first.name].url }}')">
+<header class="site-header outer " style="background-image:  url('{{ page.media[page.header.primaryImage|first.name].url|escape('css') }}')">
     <div class="inner">
         <div class="site-header-content">
             <h1 class="site-title">

--- a/templates/partials/post-card.html.twig
+++ b/templates/partials/post-card.html.twig
@@ -1,7 +1,7 @@
 <article class="post-card home-template">
     {% if page.media.images|first %}
         <a class="post-card-image-link" href="{{ post.url }}">
-            <div class="post-card-image" style="background-image: url({{ page.media.images|first.url }})"></div>
+            <div class="post-card-image" style="background-image: url({{ page.media.images|first.url|escape('css') }})"></div>
         </a>
     {% elseif page.media.youtube %}
         <a class="post-card-image-link" href="{{ post.url }}">

--- a/templates/partials/post-mini.html.twig
+++ b/templates/partials/post-mini.html.twig
@@ -1,7 +1,7 @@
 <article class="post-card home-template {{ page.home ? 'home-template' }}">
     {% if page.media.images|first %}
         <a class="post-card-image-link" href="{{ post.url }}">
-            <div class="post-card-image" style="background-image: url({{ page.media.images|first.url }})" alt="{{ post.title }}"></div>
+            <div class="post-card-image" style="background-image: url({{ page.media.images|first.url|escape('css') }})" alt="{{ post.title }}"></div>
         </a>
     {% else %}
         <a class="post-card-image-link" href="{{ post.url }}">


### PR DESCRIPTION
Addresses [this issue](https://github.com/diomed/casper/issues/16). (#16)

Twig templates that use background-image for user-added images should escape the image URLs using the Twig filter escape('css'). The filter escapes the unwanted spaces and braces in the image filename.

This PR fixes the issue.

